### PR TITLE
Add Automation & Templated sensor for z-wave battery level Closes #82

### DIFF
--- a/automation/zwave-battery-low-notification.yaml
+++ b/automation/zwave-battery-low-notification.yaml
@@ -1,0 +1,10 @@
+- alias: 'Battery Low Alert - Office Motion Sensors'
+  trigger:
+    platform: numeric_state
+    entity_id: sensor.office_motion_battery
+    below: 5
+  action:
+    service: notify.simplepush
+    data:
+      message: "Battery is low in office motion sensor."
+      title: "Z-Wave Battery Level"

--- a/sensor/zwave-battery.yaml
+++ b/sensor/zwave-battery.yaml
@@ -1,0 +1,6 @@
+- platform: template
+  sensors:
+    office_motion_battery:
+      friendly_name: 'Office Motion Sensor Battery Level'
+      value_template: '{{ states.zwave.ecolink_pir_motion_sensor_2.attributes.battery_level }}'
+      unit_of_measurement: '%'


### PR DESCRIPTION
* Show z-wave sensor battery in frontend via jinja2 templates
* simplepush notification when battery is 5% or lower.