### PR TITLE
Feed api_pasword in to your github shell command...

### DIFF
--- a/script/get_latest_config.yaml
+++ b/script/get_latest_config.yaml
@@ -2,7 +2,7 @@ alias: "Get Latest Config"
 sequence:
   - service: shell_command.update_new_commits_sensor
     data:
-      api_password: !secret api_password
+      api_password: !secret http_password
   - condition: numeric_state
     entity_id: sensor.new_commits
     above: 0

--- a/script/get_latest_config.yaml
+++ b/script/get_latest_config.yaml
@@ -1,6 +1,8 @@
 alias: "Get Latest Config"
 sequence:
   - service: shell_command.update_new_commits_sensor
+    data:
+      api_password: !secret api_password
   - condition: numeric_state
     entity_id: sensor.new_commits
     above: 0

--- a/shell_command/update_new_commits_sensor.yaml
+++ b/shell_command/update_new_commits_sensor.yaml
@@ -1,1 +1,1 @@
-bash /home/homeassistant/.homeassistant/bin/update_new_commits_sensor.sh #TODO: feed password
+bash /home/homeassistant/.homeassistant/bin/update_new_commits_sensor.sh "{{ api_password }}"


### PR DESCRIPTION
Hi Brian,

Ages ago I was looking at your repo to inspire my Maintenance package, and I just noticed you still had "TODO" next to feed password for your Github new commits sensor.

I've fixed it for you with this PR (presuming you still use it, and this isn't a reference).

Should you decide to encrypt your access with SSL at some point in the future and need to hide your URL, you could do it like this:

Script:
```
sequence:
  - service: shell_command.update_new_commits_sensor
    data:
      api_password: !secret http_password
      url: !secret curl_url
```

Shell command:
```
bash /home/homeassistant/.homeassistant/bin/update_new_commits_sensor.sh "{{ api_password }}" "{{ url }}"
```

Appropriate line in your update_new_commits_sensor.sh:
```
curl -X POST -H "x-ha-access: $1" -H "Content-Type: application/json" $2 -d "{\"state\": \"$commits\"}"

```

I can heartily recommend switching over to my maintenance package concept though :smile: - could probably knock you a personalised version up pretty quickly if you wanted?

Anyway, hope this helps 🙂 

👍 